### PR TITLE
In RFC3834, Subject must begin with Auto:

### DIFF
--- a/modoboa_postfix_autoreply/management/commands/autoreply.py
+++ b/modoboa_postfix_autoreply/management/commands/autoreply.py
@@ -60,7 +60,7 @@ def send_autoreply(sender, mailbox, armessage, original_msg):
 
     msg = MIMEText(armessage.content.encode("utf-8"), _charset="utf-8")
     set_email_headers(
-        msg, "{} Re: {}".format(armessage.subject, original_msg["Subject"]),
+        msg, "Auto: {} Re: {}".format(armessage.subject, original_msg["Subject"]),
         mailbox.user.encoded_address, sender
     )
     msg["Auto-Submitted"] = "auto-replied"


### PR DESCRIPTION
In RFC3834 Section 3.1.5.  Subject field

The prefix "Auto:" MAY be used as such an indication.  If used, this prefix SHOULD be followed by an ASCII SPACE character (0x20).
