### PR TITLE
subject must be unicode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ before_install:
 
 install:
   - pip install -e git+https://github.com/tonioo/modoboa.git#egg=modoboa
+  - pip install -q factory-boy testfixtures
   - python setup.py -q develop
   - pip install -q psycopg2
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,11 @@ install:
 before_script:
   - psql -c 'create database modoboa_test;' -U postgres
 
-script: 
+script:
+  - python -c "import modoboa_postfix_autoreply.tests"
   - cd test_project
   - coverage run --source ../modoboa_postfix_autoreply manage.py test modoboa_postfix_autoreply.tests
 
 after_success:
   - codecov
-  
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,8 @@ before_script:
   - psql -c 'create database modoboa_test;' -U postgres
 
 script:
-  - python -c "import modoboa_postfix_autoreply.tests"
   - cd test_project
+  - PYTHONPATH=".." DJANGO_SETTINGS_MODULE="test_project.settings" python -c "import modoboa_postfix_autoreply.tests"
   - coverage run --source ../modoboa_postfix_autoreply manage.py test modoboa_postfix_autoreply.tests
 
 after_success:

--- a/modoboa_postfix_autoreply/management/commands/autoreply.py
+++ b/modoboa_postfix_autoreply/management/commands/autoreply.py
@@ -60,7 +60,8 @@ def send_autoreply(sender, mailbox, armessage, original_msg):
 
     msg = MIMEText(armessage.content.encode("utf-8"), _charset="utf-8")
     set_email_headers(
-        msg, "Auto: {} Re: {}".format(armessage.subject, original_msg["Subject"]),
+        msg,
+        u"Auto: {} Re: {}".format(armessage.subject, original_msg["Subject"]),
         mailbox.user.encoded_address, sender
     )
     msg["Auto-Submitted"] = "auto-replied"


### PR DESCRIPTION
I'm getting this trace when the ARMessage contains non ascii characters:

{{{
"/var/www/modoboa/vtenv/local/lib/python2.7/site-packages/modoboa_postfix_autoreply/management/commands/autoreply.py",
    line 63, in send_autoreply     msg, "{} Re:
{}".format(armessage.subject,
    original_msg["Subject"]), UnicodeEncodeError: 'ascii' codec can't encode
    character u'\xe0' in position 18: ordinal not in range(128)
}}}

This PR fix the problem.
