### PR TITLE
Fix autoreply when no Message-ID header is found

### DIFF
--- a/modoboa_postfix_autoreply/management/commands/autoreply.py
+++ b/modoboa_postfix_autoreply/management/commands/autoreply.py
@@ -82,7 +82,7 @@ def send_autoreply(sender, mailbox, armessage, original_msg):
         "Auto-Submitted": "auto-replied",
         "Precedence": "bulk"
     }
-    message_id = original_msg.get("Message-ID").strip("\n")
+    message_id = original_msg.get("Message-ID","").strip("\n")
     if message_id:
         headers.update({"In-Reply-To": message_id, "References": message_id})
 


### PR DESCRIPTION
As far as I can see only applicable to loopback messages (`to=<info@xxxxxxxxx.com@autoreply.xxxxxxxxxxxxxxx.com>, orig_to=<info@xxxxxxxxxxxx.com>` so might not be desirable