### PR TITLE
avoid error when there is no message id. .get() return None by defaul…

### DIFF
--- a/modoboa_postfix_autoreply/management/commands/autoreply.py
+++ b/modoboa_postfix_autoreply/management/commands/autoreply.py
@@ -82,7 +82,7 @@ def send_autoreply(sender, mailbox, armessage, original_msg):
         "Auto-Submitted": "auto-replied",
         "Precedence": "bulk"
     }
-    message_id = original_msg.get("Message-ID").strip("\n")
+    message_id = original_msg.get("Message-ID", "").strip("\n")
     if message_id:
         headers.update({"In-Reply-To": message_id, "References": message_id})
 


### PR DESCRIPTION
…t and raise an attribute error 'strip'